### PR TITLE
Fix model file path and update requirements

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,11 +3,15 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 import joblib
 import numpy as np
+import os
 
 app = FastAPI()
 
 # Carrega o modelo treinado
-model = joblib.load("melhor_modelo.pkl")
+# O caminho relativo depende de onde o servidor é iniciado, então
+# calculamos o caminho absoluto baseado neste arquivo.
+MODEL_PATH = os.path.join(os.path.dirname(__file__), "melhor_modelo.pkl")
+model = joblib.load(MODEL_PATH)
 
 # Define o schema dos dados esperados (exemplo simplificado)
 class PatientData(BaseModel):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.110.0
 uvicorn[standard]==0.29.0
-scikit-learn==1.4.2
+scikit-learn==1.6.1
 joblib==1.4.2
 numpy==1.26.4
 pydantic==2.7.1


### PR DESCRIPTION
## Summary
- fix backend model path to be relative to the file
- update scikit-learn version and rename requirements file

## Testing
- `npm run lint` *(fails: react-refresh/only-export-components)*

------
https://chatgpt.com/codex/tasks/task_e_6869bd421774832684037b16efa03ce1