### PR TITLE
Fix CORS and use env API URL

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,11 +1,20 @@
 # backend/main.py
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import joblib
 import numpy as np
 import os
 
 app = FastAPI()
+
+# Permite que aplicações front-end em outros domínios/acessos consumam a API
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 # Carrega o modelo treinado
 # O caminho relativo depende de onde o servidor é iniciado, então

--- a/frontend/src/components/HeartPredictionForm.tsx
+++ b/frontend/src/components/HeartPredictionForm.tsx
@@ -19,7 +19,8 @@ export default function HeartPredictionForm() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const response = await fetch("http://localhost:8000/predict", {
+    const apiUrl = import.meta.env.VITE_API_URL || ''
+    const response = await fetch(`${apiUrl}/predict`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({


### PR DESCRIPTION
## Summary
- allow CORS requests in the FastAPI backend
- use `VITE_API_URL` for the API endpoint in the React form

## Testing
- `npm run lint` *(fails: Fast refresh only works when a file only exports components)*
- `npm run build` *(fails: several TypeScript errors)*
- `python3 -m py_compile backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6869c1e1841c8326b1ba2332f8fd8bf6