### PR TITLE
Add pytest tests for backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,11 @@ cd frontend
 npm install
 ```
 
+### Testes
+
+Execute os testes automatizados com o `pytest` na raiz do projeto:
+
+```bash
+pytest
+```
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import joblib
 import numpy as np
+import pandas as pd
 import os
 
 app = FastAPI()
@@ -40,14 +41,24 @@ class PatientData(BaseModel):
 def predict(data: PatientData):
     try:
         # Organiza os dados na mesma ordem usada no treino
-        input_data = [[
-            data.Age, data.RestingBP, data.Cholesterol, data.FastingBS,
-            data.MaxHR, data.Oldpeak, data.Sex, data.ChestPainType,
-            data.RestingECG, data.ExerciseAngina, data.ST_Slope
-        ]]
+        input_df = pd.DataFrame([
+            {
+                "Age": data.Age,
+                "RestingBP": data.RestingBP,
+                "Cholesterol": data.Cholesterol,
+                "FastingBS": data.FastingBS,
+                "MaxHR": data.MaxHR,
+                "Oldpeak": data.Oldpeak,
+                "Sex": data.Sex,
+                "ChestPainType": data.ChestPainType,
+                "RestingECG": data.RestingECG,
+                "ExerciseAngina": data.ExerciseAngina,
+                "ST_Slope": data.ST_Slope,
+            }
+        ])
 
         # Faz a predição
-        prediction = model.predict(input_data)[0]
+        prediction = model.predict(input_df)[0]
         return {"prediction": int(prediction)}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,6 @@ scikit-learn==1.6.1
 joblib==1.4.2
 numpy==1.26.4
 pydantic==2.7.1
+pytest==8.1.1
+httpx==0.27.0
+pandas==2.2.2

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,0 +1,33 @@
+from fastapi.testclient import TestClient
+import sys
+from pathlib import Path
+
+# Garantir que o diretório raiz esteja no caminho de importação
+ROOT_DIR = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT_DIR))
+
+from backend.main import app
+
+client = TestClient(app)
+
+
+def test_predict_endpoint():
+    sample_data = {
+        "Age": 40,
+        "RestingBP": 120,
+        "Cholesterol": 200,
+        "FastingBS": 0,
+        "MaxHR": 150,
+        "Oldpeak": 1.0,
+        "Sex": "M",
+        "ChestPainType": "ATA",
+        "RestingECG": "Normal",
+        "ExerciseAngina": "N",
+        "ST_Slope": "Up",
+    }
+    response = client.post("/predict", json=sample_data)
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, dict)
+    assert "prediction" in data
+    assert isinstance(data["prediction"], int)


### PR DESCRIPTION
## Summary
- add backend tests using TestClient
- load prediction pipeline with pandas DataFrame
- add pytest, httpx and pandas to requirements
- document how to run tests in README

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869c36f8aa08326a83821950b9bfe2b